### PR TITLE
added sfpr_xref_rd_tenure_names 

### DIFF
--- a/inst/staticexports/ng_fpr.R
+++ b/inst/staticexports/ng_fpr.R
@@ -261,7 +261,7 @@ sfpr_xref_rd_tenure_names <- function(){
                    "Wetzinkwa Community Forest Corporation", "Wetzinkwa Community Forest",
                    "West Fraser Mills Ltd.", "West Fraser",
                    "Timber Sales Manager", "BCTS",
-                   "Skeena Stikine Natural Resource District", "MoF",
+                   "DISTRICT MANAGER SKEENA STIKINE (DSS)", "MoF",
                    "DISTRICT MANAGER PRINCE GEORGE", "MoF",
                    "Winton Global Lumber Ltd.", "Winton"
 

--- a/inst/staticexports/ng_fpr.R
+++ b/inst/staticexports/ng_fpr.R
@@ -251,3 +251,20 @@ sfpr_structure_size_type <- function(
 
 }
 
+
+sfpr_xref_rd_tenure_names <- function(){
+  tibble::tribble( ~client_name, ~client_name_abb,
+                   "DISTRICT MANAGER NADINA (DND)",       "FLNR DND",
+                   "CANADIAN FOREST PRODUCTS LTD.",         "Canfor",
+                   "SOLID GROUND CONTRACTING LTD",    "Solid Ground",
+                   "CHINOOK COMFOR LIMITED",        "Chinook Comfor",
+                   "Wetzinkwa Community Forest Corporation", "Wetzinkwa Community Forest",
+                   "West Fraser Mills Ltd.", "West Fraser",
+                   "Timber Sales Manager", "BCTS",
+                   "Skeena Stikine Natural Resource District", "MoF",
+                   "DISTRICT MANAGER PRINCE GEORGE", "MoF",
+                   "Winton Global Lumber Ltd.", "Winton"
+
+)
+}
+

--- a/inst/staticexports/ng_fpr.R
+++ b/inst/staticexports/ng_fpr.R
@@ -268,3 +268,14 @@ sfpr_xref_rd_tenure_names <- function(){
 )
 }
 
+
+# Retrieves the elevation of a site
+#' @param dat Sf containing the site names
+
+sfpr_get_elev <- function(dat){
+    poisspatial::ps_elevation_google(dat,
+                                     key = Sys.getenv('GOOG_API_KEY'),
+                                     Z = 'elev') |>
+      mutate(elev = round(elev, 0))
+  }
+


### PR DESCRIPTION
added sfpr_xref_rd_tenure_names so we can have a table in the guidebook with the client names and abbreviated names which is super helpful when QAing the data in QGIS.

Related to https://github.com/NewGraphEnvironment/fish_passage_guidebook/pull/20